### PR TITLE
Enumerable change

### DIFF
--- a/GenericDeepEquality/GenericDeepEqualityComparer.cs
+++ b/GenericDeepEquality/GenericDeepEqualityComparer.cs
@@ -22,7 +22,7 @@ namespace GenericDeepEquality
                 {
                     case IComparable xComparable:
                         var yComparable = (IComparable)y;
-                        return xComparable.Equals(yComparable);
+                        return xComparable.CompareTo(yComparable)  == 0;
                     case IEnumerable<object> xEnumerable:
                         var yEnumerable = (IEnumerable<object>)y;
                         return EnumerableComparison(xEnumerable, yEnumerable);

--- a/GenericDeepEquality/GenericDeepEqualityComparer.cs
+++ b/GenericDeepEquality/GenericDeepEqualityComparer.cs
@@ -20,54 +20,12 @@ namespace GenericDeepEquality
             {
                 switch (x)
                 {
+                    case IComparable xComparable:
+                        var yComparable = (IComparable)y;
+                        return xComparable.Equals(yComparable);
                     case IEnumerable<object> xEnumerable:
                         var yEnumerable = (IEnumerable<object>)y;
                         return EnumerableComparison(xEnumerable, yEnumerable);
-                    case bool xBool:
-                        var yBool = (bool)y;
-                        return xBool == yBool;
-                    case byte xByte:
-                        var yByte = (byte)y;
-                        return xByte == yByte;
-                    case sbyte xSByte:
-                        var ySByte = (sbyte)y;
-                        return xSByte == ySByte;
-                    case char xChar:
-                        var yChar = (char)y;
-                        return xChar == yChar;
-                    case decimal xDecimal:
-                        var yDecimal = (decimal)y;
-                        return xDecimal == yDecimal;
-                    case double xDouble:
-                        var yDouble = (double)y;
-                        return xDouble == yDouble;
-                    case float xFloat:
-                        var yFloat = (float)y;
-                        return xFloat == yFloat;
-                    case int xInt:
-                        var yInt = (int)y;
-                        return xInt == yInt;
-                    case uint xUInt:
-                        var yUInt = (uint)y;
-                        return xUInt == yUInt;
-                    case long xLong:
-                        var yLong = (long)y;
-                        return xLong == yLong;
-                    case ulong xULong:
-                        var yULong = (ulong)y;
-                        return xULong == yULong;
-                    case short xShort:
-                        var yShort = (short)y;
-                        return xShort == yShort;
-                    case ushort xUShort:
-                        var yUShort = (ushort)y;
-                        return xUShort == yUShort;
-                    case string xString:
-                        var yString = (string)y;
-                        return xString.Equals(yString);
-                    case Guid xGuid:
-                        var yGuid = (Guid)y;
-                        return xGuid.Equals(yGuid);
                     default:
                         return GenericComparision(x, y);
                 }

--- a/GenericDeepEquality/GenericDeepEqualityComparer.cs
+++ b/GenericDeepEquality/GenericDeepEqualityComparer.cs
@@ -18,17 +18,23 @@ namespace GenericDeepEquality
             }
             else
             {
-                switch (x)
-                {
-                    case IComparable xComparable:
-                        var yComparable = (IComparable)y;
-                        return xComparable.CompareTo(yComparable)  == 0;
-                    case IEnumerable<object> xEnumerable:
-                        var yEnumerable = (IEnumerable<object>)y;
-                        return EnumerableComparison(xEnumerable, yEnumerable);
-                    default:
-                        return GenericComparision(x, y);
-                }
+                var xEquatableType = x.GetType().GetInterfaces()
+                    .Where(xInter => xInter.IsGenericType)
+                    .Where(xInter => xInter.GetGenericTypeDefinition() 
+                        == typeof(IEquatable<>));
+
+                if (xEquatableType.Count() > 0 ) {
+                    return x.Equals(y);
+                } else {  
+                    switch (x) {
+                        case IEnumerable<object> xEnumerable:
+                            var yEnumerable = (IEnumerable<object>)y;
+                            return EnumerableComparison(xEnumerable, yEnumerable);
+                        default:
+                            return GenericComparision(x, y);
+                    }
+
+                }            
             }
         }
 

--- a/Tests/GenericDeepEqualityTest.cs
+++ b/Tests/GenericDeepEqualityTest.cs
@@ -339,7 +339,7 @@ namespace Tests
         }
 
         [Fact]
-        public void EqualsDataTimeTrue()
+        public void EqualsDateTimeTrue()
         {
             DateTime x = DateTime.Parse("12/7/2019");
             DateTime y = DateTime.Parse("12/7/2019");
@@ -349,7 +349,7 @@ namespace Tests
         }
 
         [Fact]
-        public void EqualsDataTimeFalse()
+        public void EqualsDateTimeFalse()
         {
             DateTime x = DateTime.Parse("12/7/2019");
             DateTime y = DateTime.Parse("12/7/2029");


### PR DESCRIPTION
Using reflection to determine equality. Found a method to determine if IEquatable is implemented, all "primatives" implement this and any other classes that implement it shortcut the equality determination and allows for  equality to be controlled by the class creator, while maintaining the ability to compare classes that do not define equality.